### PR TITLE
Added support for getting authentication token from environment variables as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,16 @@ npx octoget@latest <path> [<dir>] [...options]
 ### Options
 
 - `--force`: Download into an existing directory, overwriting its contents.
-- `--auth`: Use a custom authorization token for accessing private repositories. (Alternatively, set the `OCTOGET_AUTH` environment variable.)
+- `--auth`: Use a custom authorization token for using GitHub GraphQL API. (Alternatively, set the `OCTOGET_AUTH` environment variable.)
 
 ### Examples
 
 ```sh
 # Download a public repository to the current directory
-npx octoget@latest aster-mnch/octoget
+OCTOGET_AUTH=ghu_XXXXX npx octoget@latest aster-mnch/octoget
 
 # Download a repository to a specified directory
-npx octoget@latest aster-mnch/octoget path/to/dir
-
-# Download a private repository with an authorization token
-npx octoget@latest aster-mnch/private-repository --auth=ghu_XXXXX
+OCTOGET_AUTH=ghu_XXXXX npx octoget@latest aster-mnch/octoget path/to/dir
 ```
 
 ## Usage (Code)
@@ -76,7 +73,7 @@ The function downloads a GitHub repository and saves it to a specified directory
 - **options**: (object) An optional object containing:
   - **dir**: (string) The directory to which the repository will be downloaded.
   - **force**: (boolean) If `true`, allows downloading into an existing directory.
-  - **auth**: (string) Authorization token for accessing private repositories.
+  - **auth**: (string) Authorization token for using GitHub GraphQL API.
 
 #### Example Usage:
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "@octokit/graphql": "^8.1.1",
     "citty": "^0.1.6",
-    "pathe": "^1.1.2"
+    "pathe": "^1.1.2",
+    "std-env": "^3.8.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
+      std-env:
+        specifier: ^3.8.0
+        version: 3.8.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,9 @@ const main = defineCommand({
 
     const auth = args.auth ?? process.env.OCTOGET_AUTH;
     if (!auth) {
-      throw new Error('--auth options or `OCTOGET_AUTH` environment variable is required.');
+      throw new Error(
+        '--auth options or `OCTOGET_AUTH` environment variable is required.',
+      );
     }
 
     await download(path, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { defineCommand, runMain as runMainOrig } from 'citty';
+import { process } from 'std-env';
 import pkgInfo from '../package.json' assert { type: 'json' };
 import { download } from './octoget';
 
@@ -33,7 +34,10 @@ const main = defineCommand({
     },
   },
   async run({ args }) {
-    const { path, dir, force, auth } = args;
+    const { path, dir, force } = args;
+
+    const auth = args.auth ?? process.env.OCTOGET_AUTH;
+
     await download(path, {
       dir,
       force,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,9 @@ const main = defineCommand({
     const { path, dir, force } = args;
 
     const auth = args.auth ?? process.env.OCTOGET_AUTH;
+    if (!auth) {
+      throw new Error('--auth options or `OCTOGET_AUTH` environment variable is required.');
+    }
 
     await download(path, {
       dir,

--- a/src/octoget.ts
+++ b/src/octoget.ts
@@ -5,7 +5,7 @@ import { parseGitHubURI } from './utils';
 
 export async function download(
   path: string,
-  options?: DownloadOption,
+  options: DownloadOption,
 ): Promise<DownloadResult> {
   const { owner, repo } = parseGitHubURI(path);
   const dir = resolveDir(options?.dir);

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export type DownloadOption = {
   dir?: string;
   /** If `true`, allows downloading into an existing directory. */
   force?: boolean;
-  /** Authorization token for accessing private repositories. */
+  /** Authorization token for using GitHub GraphQL API. */
   auth: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type DownloadOption = {
   /** If `true`, allows downloading into an existing directory. */
   force?: boolean;
   /** Authorization token for accessing private repositories. */
-  auth?: string;
+  auth: string;
 };
 
 export type DownloadResult = {


### PR DESCRIPTION
and make auth token mandatory cuz GitHub GraphQL API requires it.

ref: https://docs.github.com/en/enterprise-cloud@latest/graphql/guides/forming-calls-with-graphql#authenticating-with-a-personal-access-token
