### PR TITLE
fix: add a case where file content is a binary

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import fs from 'node:fs';
 import { resolve } from 'pathe';
 
@@ -21,5 +22,6 @@ export async function writeFile(
   },
 ) {
   const filepath = resolve(options?.relativePath ?? '.', path);
-  await fs.promises.writeFile(filepath, content);
+  const data = new Uint8Array(Buffer.from(content));
+  await fs.promises.writeFile(filepath, data);
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -5,7 +5,10 @@ type TreeEntry = {
   path: string;
   type: 'blob' | 'tree';
   object: {
-    text: string;
+    /** UTF8 text data or null if the Blob is binary. */
+    text: string | null;
+    /** Indicates whether the Blob is binary or text. Returns null if unable to determine the encoding. */
+    isBinary: boolean;
   };
 };
 

--- a/src/octoget.ts
+++ b/src/octoget.ts
@@ -59,8 +59,10 @@ async function fetchAndSaveEntries(
   for (const entry of entries) {
     switch (entry.type) {
       case 'blob':
-        // TODO check if the file exists.
-        await writeFile(entry.path, entry.object.text, options);
+        // TODO handling binary files
+        if (entry.object.text != null) {
+          await writeFile(entry.path, entry.object.text, options);
+        }
         break;
       case 'tree':
         nextDirs.push(entry.path);


### PR DESCRIPTION
TODO Use REST instead of GraphQL for large files.

ref: https://docs.github.com/en/rest/git/blobs#get-a-blob